### PR TITLE
Fix deprecated id attribute

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -28,7 +28,7 @@
         <!--<header-file src="src/ios/Flurry.h" />-->
         <header-file src="src/ios/FlurryAnalyticsPlugin.h"/>
         <source-file src="src/ios/FlurryAnalyticsPlugin.m"/>
-        <pod id="Flurry-iOS-SDK/FlurrySDK"/>
+        <pod name="Flurry-iOS-SDK/FlurrySDK"/>
     </platform>
 
     <platform name="android">


### PR DESCRIPTION
Notes - cordova-plugin-cocoapods-support:

Pod "id" was deprecated in version 1.3.0. You should use "name" instead. But don't worry "id" will continue to work. I made this change to better align with the podspec.